### PR TITLE
Bug fixes for hang nginx-cache-purge process.

### DIFF
--- a/nginx-cache-purge
+++ b/nginx-cache-purge
@@ -46,7 +46,12 @@ while(true)
     }
     catch(\Exception $e)
     {
-        // this means inotify has failed so lets exit so that die so that supervisor will restart us
+        // this means inotify has failed so let's exit so that supervisor will
+        // restart us
+        // we also need to kill our children; inotifywait runs forever in a
+        // loop and if not interrupted we would be stuck here waiting for it
+        // to exit on its own
+        $inotify->killInotify();
         exit(1);
     }
 	$cache->update($updates);

--- a/src/NginxCP/Inotify.php
+++ b/src/NginxCP/Inotify.php
@@ -15,7 +15,7 @@ class Inotify
         $this->path = $path;
 
         // we can leak these guys so cleanup on start
-        $this->killStaleInotify();
+        $this->killInotify();
 
 		// start a inotifywait process
 		$this->proc = popen("$this->cmd $path", "r");
@@ -51,7 +51,7 @@ class Inotify
 		return $updates;
 	}
 
-    public function killStaleInotify()
+    public function killInotify()
     {
         exec('ps aux | grep '.escapeshellarg($this->cmd).' | grep -v grep', $output);
         foreach($output as $line)

--- a/src/NginxCP/Inotify.php
+++ b/src/NginxCP/Inotify.php
@@ -56,7 +56,7 @@ class Inotify
         exec('ps aux | grep '.escapeshellarg($this->cmd).' | grep -v grep', $output);
         foreach($output as $line)
         {
-            if (preg_match('/^[a-zA-Z-]+ ([0-9]+) /', $line, $match))
+            if (preg_match('/^[a-zA-Z-]+\s+([0-9]+) /', $line, $match))
             {
                 $pid = $match[1];
                 posix_kill($pid, SIGKILL);


### PR DESCRIPTION
We can end up in a state where the inotify ping has failed and we try to exit but we still have the child inotifywait process running. Before we can exit ourselves we need to make sure any child processes are terminated otherwise we get stuck waiting for them to exit on their own.